### PR TITLE
final missing code doc comments, removed auto generated explicit bind…

### DIFF
--- a/RegenerativeDistributedCache.Tests/app.config
+++ b/RegenerativeDistributedCache.Tests/app.config
@@ -3,10 +3,6 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.IO.Compression" publicKeyToken="b77a5c561934e089" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.2.0" newVersion="4.1.2.0" />
-      </dependentAssembly>
-      <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
       </dependentAssembly>

--- a/RegenerativeDistributedCache/Interfaces/ICorrelatedAwaiter.cs
+++ b/RegenerativeDistributedCache/Interfaces/ICorrelatedAwaiter.cs
@@ -10,7 +10,16 @@ namespace RegenerativeDistributedCache.Interfaces
     /// <typeparam name="TMessage"></typeparam>
     public interface ICorrelatedAwaiter<TMessage> : IDisposable
     {
+        /// <summary>
+        /// Cancel an awaiter ahead of disposing it. This will set the task completion
+        /// result to cancelled if it isn't already complete/errored.
+        /// </summary>
         void Cancel();
+
+        /// <summary>
+        /// Task which can be waited on (e.g. via await, .Wait() or .Result).
+        /// Task result is of TMessage which was send to NotifyAwaiters.
+        /// </summary>
         Task<TMessage> Task { get; }
     }
 }

--- a/RegenerativeDistributedCache/RegenerativeCacheManager.cs
+++ b/RegenerativeDistributedCache/RegenerativeCacheManager.cs
@@ -360,7 +360,7 @@ namespace RegenerativeDistributedCache
 
         }
 
-        public void Dispose()
+        void IDisposable.Dispose()
         {
             _underlyingCache?.Dispose();
             _regenTriggers?.Dispose();


### PR DESCRIPTION
…ing redirect (from Tests project) that wasn't needed and caused build warning message.